### PR TITLE
Correctly retrieve name of the test case when case#klass is nil

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -82,12 +82,16 @@ module Minitest
       def test_class(result)
         # Minitest broke API between 5.10 and 5.11 this gets around Result object
         if result.nil?
-          nil
-        elsif result.respond_to? :klass
-          Suite.new(result.klass)
-        else
-          Suite.new(result.class.name)
+          return nil
         end
+        result_class = nil
+        if result.respond_to? :klass
+          result_class = result.klass
+        end
+        if result_class.nil?
+          result_class = result.class.name
+        end
+        Suite.new(result_class)
       end
 
       def print_colored_status(test)

--- a/test/unit/minitest/spec_reporter_test.rb
+++ b/test/unit/minitest/spec_reporter_test.rb
@@ -57,6 +57,14 @@ module MinitestReportersTest
 
       refute error_msg, error_msg
     end
+
+    def test_suite_class_retrieval
+      Object.const_set('MockingTest', Class.new { def klass() nil end})
+      @reporter.io = StringIO.new
+      @reporter.before_test(MockingTest.new)
+
+      assert_match /MockingTest/, @reporter.io.string
+    end
   end
 end
 


### PR DESCRIPTION
BaseReporter fails to get name of the test case in `before_test` handler #290

In ActionRecord TestCase attribute `klass` could return nil. That's why it necessary to try get name of the class from `class.name`