### PR TITLE
Print errors at the bottom when using Spec reporter

### DIFF
--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -18,6 +18,11 @@ module Minitest
 
       def report
         super
+        failed_tests = tests.select { |test| !test.failures.empty? }
+        unless failed_tests.empty?
+          print(red 'Failures and errors:')
+          failed_tests.each { |test| print_failure(test) }
+        end
         puts('Finished in %.5fs' % total_time)
         print('%d tests, %d assertions, ' % [count, assertions])
         color = failures.zero? && errors.zero? ? :green : :red
@@ -29,7 +34,6 @@ module Minitest
       def record(test)
         super
         record_print_status(test)
-        record_print_failures_if_any(test)
       end
 
       protected
@@ -42,19 +46,20 @@ module Minitest
         puts
       end
 
+      def print_failure(test)
+        puts
+        record_print_status(test)
+        print_info(test.failure, test.error?)
+        puts "Location:\n\t #{test.source_location.join(':')}"
+        puts
+      end
+
       def record_print_status(test)
         test_name = test.name.gsub(/^test_: /, 'test:')
         print pad_test(test_name)
         print_colored_status(test)
         print(" (%.2fs)" % test.time) unless test.time.nil?
         puts
-      end
-
-      def record_print_failures_if_any(test)
-        if !test.skipped? && test.failure
-          print_info(test.failure, test.error?)
-          puts
-        end
       end
     end
   end

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -62,6 +62,7 @@ module Minitest
 
       def print_failure(test)
         puts
+        puts test.klass
         record_print_status(test)
         print_info(test.failure, test.error?)
         puts "Location:\n\t #{test.source_location.join(':')}"


### PR DESCRIPTION
This is an initial attempt for a modification to the Spec reporter that is much more convenient for me personally. I'm using this reporter in [`elasticsearch-xpack`](https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-xpack), and it would be much more practical for me to see the errors at the bottom. With this change, the error is still reported with the rest of the tests:
![image](https://user-images.githubusercontent.com/689327/101149137-6bc22c80-3616-11eb-82d7-dcf3f3ac0671.png)

But you can see the detail in errors or failures at the bottom of the report:
![image](https://user-images.githubusercontent.com/689327/101054093-6d411580-3580-11eb-92d4-ea60b2036c9a.png)

Would this be convenient to add? Maybe as an option?

Related: #304