### PR TITLE
Allow specifying the output folder and file name via env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.3...master)
 
+* Added support for environment variables to define the output location of HTML reports. [#311](https://github.com/minitest-reporters/minitest-reporters/pull/311) contributed by [estebanbouza](https://github.com/estebanbouza)
+
 ### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
 
 * fixed rare compatability issue between JUnitReporter and older versions of Minitest [#272](https://github.com/minitest-reporters/minitest-reporters/pull/272) contributed by [chakrit](https://github.com/chakrit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.4...master)
+### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.3...master)
 
-### [1.4.4](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.4)
+### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
 
 * fixed rare compatability issue between JUnitReporter and older versions of Minitest [#272](https://github.com/minitest-reporters/minitest-reporters/pull/272) contributed by [chakrit](https://github.com/chakrit)
 * fixed JUnitReporter to use a relative file path if a file path is absolute [#305](https://github.com/minitest-reporters/minitest-reporters/issues/305)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.3...master)
+### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.4...master)
 
-### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
+### [1.4.4](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.4)
 
 * fixed rare compatability issue between JUnitReporter and older versions of Minitest [#272](https://github.com/minitest-reporters/minitest-reporters/pull/272) contributed by [chakrit](https://github.com/chakrit)
 * fixed JUnitReporter to use a relative file path if a file path is absolute [#305](https://github.com/minitest-reporters/minitest-reporters/issues/305)

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -60,9 +60,9 @@ module Minitest
         defaults = {
           :title           => 'Test Results',
           :erb_template    => "#{File.dirname(__FILE__)}/../templates/index.html.erb",
-          :reports_dir     => 'test/html_reports',
+          :reports_dir     => ENV['MINITEST_HTML_REPORTS_DIR'] || 'test/html_reports',
           :mode            => :safe,
-          :output_filename => 'index.html',
+          :output_filename => ENV['MINITEST_HTML_REPORTS_FILENAME'] || 'index.html',
         }
 
         settings = defaults.merge(args)

--- a/lib/minitest/reporters/version.rb
+++ b/lib/minitest/reporters/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Reporters
-    VERSION = '1.4.4'.freeze
+    VERSION = '1.4.3'.freeze
   end
 end

--- a/lib/minitest/reporters/version.rb
+++ b/lib/minitest/reporters/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Reporters
-    VERSION = '1.4.3'.freeze
+    VERSION = '1.4.4'.freeze
   end
 end


### PR DESCRIPTION
Allow specifying the output folder and file name via env variables for the HTML reporter.