### PR TITLE
Fix ProgressReporter accuracy on skipped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.3...master)
 
 * Added support for environment variables to define the output location of HTML reports. [#311](https://github.com/minitest-reporters/minitest-reporters/pull/311) contributed by [estebanbouza](https://github.com/estebanbouza)
-* Fixed ProgressReporter accuracy on skipped tests while `detailed_skip` is disabled
+* Fixed ProgressReporter accuracy on skipped tests while `detailed_skip` is disabled [#312](https://github.com/minitest-reporters/minitest-reporters/pull/312) contributed by [seven1m](https://github.com/seven1m)
 
 ### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### [dev](https://github.com/kern/minitest-reporters/compare/v1.4.3...master)
 
 * Added support for environment variables to define the output location of HTML reports. [#311](https://github.com/minitest-reporters/minitest-reporters/pull/311) contributed by [estebanbouza](https://github.com/estebanbouza)
+* Fixed ProgressReporter accuracy on skipped tests while `detailed_skip` is disabled
 
 ### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
 

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -48,7 +48,7 @@ module Minitest
 
       def record(test)
         super
-        return if test.skipped? && !@detailed_skip
+        return show if test.skipped? && !@detailed_skip
         if test.failure
           print "\e[0m\e[1000D\e[K"
           print_colored_status(test)


### PR DESCRIPTION
When `detailed_skip` is turned off (it's on by default), the `ProgressReporter` would not advance the progress bar on skipped tests.