### PR TITLE
Add file attribute on JUnit <testcase> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added support for environment variables to define the output location of HTML reports. [#311](https://github.com/minitest-reporters/minitest-reporters/pull/311) contributed by [estebanbouza](https://github.com/estebanbouza)
 * Fixed ProgressReporter accuracy on skipped tests while `detailed_skip` is disabled [#312](https://github.com/minitest-reporters/minitest-reporters/pull/312) contributed by [seven1m](https://github.com/seven1m)
+* Added `file` attribute to `<testcase>` tags in JUnitReporter for CircleCI compatibility [#313](https://github.com/minitest-reporters/minitest-reporters/pull/313) contributed by [nbudin](https://github.com/nbudin)
 
 ### [1.4.3](https://github.com/kern/minitest-reporters/compare/v1.4.2...v1.4.3)
 
@@ -67,7 +68,7 @@
 
 * SpecReporter do not print exception name any more (unless it is an test error) [#264](https://github.com/kern/minitest-reporters/issues/264)
 * Fixed loading error caused by fix for [#265](https://github.com/kern/minitest-reporters/pull/265)
-  see [#267](https://github.com/kern/minitest-reporters/issues/267) and 
+  see [#267](https://github.com/kern/minitest-reporters/issues/267) and
   [#268](https://github.com/kern/minitest-reporters/pull/268) for more details.
 
 ### [1.3.1](https://github.com/kern/minitest-reporters/compare/v1.3.1.beta1...v1.3.1)

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -90,7 +90,7 @@ module Minitest
           tests.each do |test|
             lineno = get_source_location(test).last
             xml.testcase(:name => test.name, :lineno => lineno, :classname => suite, :assertions => test.assertions,
-                         :time => test.time) do
+                         :time => test.time, :file => file_path) do
               xml << xml_message_for(test) unless test.passed?
             end
           end


### PR DESCRIPTION
CircleCI requires a `file` attribute on the `<testcase>` tag in order to recognize what files each case belong to - it can't use the `filepath` attribute on the `<testsuite>` tag that minitest-reporters puts there already, unfortunately.

They do do this in [their own minitest-ci gem](https://github.com/circleci/minitest-ci/blob/8b72b0f32f154d91b53d63d1d0a8a8fb3b01d726/lib/minitest/ci_plugin.rb#L141), so it would be awesome if minitest-reporters could support it also!