### PR TITLE
Add Github Actions reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,15 @@ Detection of those systems is based on presence of certain ENV variables and are
 The following reporters are provided:
 
 ```ruby
-Minitest::Reporters::DefaultReporter  # => Redgreen-capable version of standard Minitest reporter
-Minitest::Reporters::SpecReporter     # => Turn-like output that reads like a spec
-Minitest::Reporters::ProgressReporter # => Fuubar-like output with a progress bar
-Minitest::Reporters::RubyMateReporter # => Simple reporter designed for RubyMate
-Minitest::Reporters::RubyMineReporter # => Reporter designed for RubyMine IDE and TeamCity CI server
-Minitest::Reporters::JUnitReporter    # => JUnit test reporter designed for JetBrains TeamCity
-Minitest::Reporters::MeanTimeReporter # => Produces a report summary showing the slowest running tests
-Minitest::Reporters::HtmlReporter     # => Generates an HTML report of the test results
+Minitest::Reporters::DefaultReporter       # => Redgreen-capable version of standard Minitest reporter
+Minitest::Reporters::SpecReporter          # => Turn-like output that reads like a spec
+Minitest::Reporters::ProgressReporter      # => Fuubar-like output with a progress bar
+Minitest::Reporters::RubyMateReporter      # => Simple reporter designed for RubyMate
+Minitest::Reporters::RubyMineReporter      # => Reporter designed for RubyMine IDE and TeamCity CI server
+Minitest::Reporters::JUnitReporter         # => JUnit test reporter designed for JetBrains TeamCity
+Minitest::Reporters::MeanTimeReporter      # => Produces a report summary showing the slowest running tests
+Minitest::Reporters::HtmlReporter          # => Generates an HTML report of the test results
+Minitest::Reporters::GithubActionsReporter # => Generate Annotations for use with Github Actions
 ```
 
 Options can be passed to these reporters at construction-time, e.g. to force

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,7 @@ task :gallery do
     "RubyMineReporter",
     "HtmlReporter",
     "MeanTimeReporter",
+    "GithubActionsReporter",
   ].each do |reporter|
     puts
     puts "-" * 72

--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -17,6 +17,7 @@ module Minitest
     autoload :JUnitReporter, "minitest/reporters/junit_reporter"
     autoload :HtmlReporter, "minitest/reporters/html_reporter"
     autoload :MeanTimeReporter, "minitest/reporters/mean_time_reporter"
+    autoload :GithubActionsReporter, "minitest/reporters/github_actions_reporter"
 
     class << self
       attr_accessor :reporters

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -131,6 +131,42 @@ module Minitest
         trace = filter_backtrace(e.backtrace)
         trace.each { |line| print_with_info_padding(line) }
       end
+
+      def get_source_location(result)
+        if result.respond_to? :source_location
+          result.source_location
+        else
+          result.method(result.name).source_location
+        end
+      end
+
+      def location(exception)
+        last_before_assertion = ''
+        exception.backtrace.reverse_each do |s|
+          break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+
+          last_before_assertion = s
+        end
+
+        last_before_assertion.sub(/:in .*$/, '')
+      end
+
+      def get_relative_path(result, base_path)
+        file_path = Pathname.new(get_source_location(result).first)
+        base_path = Pathname.new(base_path)
+
+        if file_path.absolute?
+          file_path.relative_path_from(base_path)
+        else
+          file_path
+        end
+      end
+
+      def print_run_options
+        puts
+        puts("# Running tests with run options %s:" % options[:args])
+        puts
+      end
     end
   end
 end

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -25,13 +25,7 @@ module Minitest
 
       def start
         super
-        on_start
-      end
-
-      def on_start
-        puts
-        puts("# Running tests with run options %s:" % options[:args])
-        puts
+        print_run_options
       end
 
       def before_test(test)
@@ -155,14 +149,6 @@ module Minitest
       def relative_path(path)
         Pathname.new(path).relative_path_from(Pathname.new(Dir.getwd))
       end
-      
-      def get_source_location(result)
-        if result.respond_to? :klass
-          result.source_location
-        else
-          result.method(result.name).source_location
-        end
-      end
 
       def color?
         return @color if defined?(@color)
@@ -201,16 +187,6 @@ module Minitest
         when skips > 0; :skip
         else :pass
         end
-      end
-
-      def location(exception)
-        last_before_assertion = ''
-        exception.backtrace.reverse_each do |s|
-          break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
-          last_before_assertion = s
-        end
-
-        last_before_assertion.sub(/:in .*$/, '')
       end
 
       def message_for(test)

--- a/lib/minitest/reporters/github_actions_reporter.rb
+++ b/lib/minitest/reporters/github_actions_reporter.rb
@@ -1,0 +1,55 @@
+# Inspired by the rubocop formatter.
+# https://github.com/rubocop/rubocop/blob/2f8239f61bd41fe672a4cd9d6f24e334eba7854a/lib/rubocop/formatter/git_hub_actions_formatter.rb
+
+module Minitest
+  module Reporters
+    # Simple reporter designed for Github Actions
+    class GithubActionsReporter < BaseReporter
+      ESCAPE_MAP = { '%' => '%25', "\n" => '%0A', "\r" => '%0D' }.freeze
+
+      def initialize(base_path = Dir.pwd)
+        super({})
+        @base_path = base_path
+      end
+
+      def start
+        super
+
+        print_run_options
+      end
+
+      def record(test)
+        super
+
+        print(message_for(test))
+      end
+
+      def message_for(test)
+        if test.passed? || test.skipped?
+          nil
+        elsif test.failure
+          to_annotation(test, "Failure")
+        elsif test.error?
+          to_annotation(test, "Error")
+        end
+      end
+
+      private
+
+      def to_annotation(test, failure_type)
+        message = "#{failure_type}: #{test.name}\n\n#{test.failure.message}"
+        line_number = location(test.failure).split(":").last
+
+        "\n::error file=%<file>s,line=%<line>d::%<message>s" % {
+          file: get_relative_path(test, @base_path),
+          line: line_number,
+          message: github_escape(message),
+        }
+      end
+
+      def github_escape(string)
+        string.gsub(Regexp.union(ESCAPE_MAP.keys), ESCAPE_MAP)
+      end
+    end
+  end
+end

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -203,16 +203,6 @@ module Minitest
         end
       end
 
-      # taken from the JUnit reporter
-      def location(exception)
-        last_before_assertion = ''
-        exception.backtrace.reverse_each do |s|
-          break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
-          last_before_assertion = s
-        end
-        last_before_assertion.sub(/:in .*$/, '')
-      end
-
       def total_time_to_hms
         return ('%.2fs' % total_time) if total_time < 1
 

--- a/test/fixtures/github_actions_test.rb
+++ b/test/fixtures/github_actions_test.rb
@@ -1,0 +1,18 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'minitest/reporters'
+require 'minitest/reporters/mean_time_reporter'
+
+Minitest::Reporters.use! Minitest::Reporters::GithubActionsReporter.new
+
+class TestClass < Minitest::Test
+  def test_assertion
+    assert true
+  end
+
+  def test_fail
+    if true
+      assert false
+    end
+  end
+end

--- a/test/integration/reporters/github_actions_reporter_test.rb
+++ b/test/integration/reporters/github_actions_reporter_test.rb
@@ -1,0 +1,13 @@
+require_relative "../../test_helper"
+
+module MinitestReportersTest
+  class GithubActionsReporterTest < TestCase
+    def test_output_format
+      fixtures_directory = File.expand_path('../../fixtures', __dir__)
+      test_filename = File.join(fixtures_directory, 'github_actions_test.rb')
+      output = `ruby #{test_filename} 2>&1`
+      refute_match 'test_assertion', output
+      assert_match '::error file=test/fixtures/github_actions_test.rb,line=15::Failure: test_fail', output
+    end
+  end
+end

--- a/test/unit/minitest/junit_reporter_test.rb
+++ b/test/unit/minitest/junit_reporter_test.rb
@@ -14,7 +14,7 @@ module MinitestReportersTest
     def test_relative_path
       path = Pathname.new(__FILE__).relative_path_from(Pathname.new(Dir.pwd)).to_s
       @result.source_location = [path, 10]
-      relative_path = @reporter.get_relative_path(@result)
+      relative_path = @reporter.send(:get_relative_path, @result, @reporter.base_path)
       assert_equal path, relative_path.to_s
     end
 


### PR DESCRIPTION
See #330

First commit moves a few functions from invdividual reporters into the base one for reuse. The second commit is the actual reporter. I can drop the first commit if you want that.

Here's a screenshot of how it looks like in Githubs UI:

![image](https://user-images.githubusercontent.com/14981592/202759692-b8a7bfb6-96a2-4ff2-a685-f4dfc513f143.png)