### PR TITLE
Turn on color output for CI providers that support it

### DIFF
--- a/lib/minitest/reporters/ansi.rb
+++ b/lib/minitest/reporters/ansi.rb
@@ -2,10 +2,24 @@ module Minitest
   module Reporters
     module ANSI
       module Code
+
         def self.color?
           return false if ENV['MINITEST_REPORTERS_MONO']
+          return true if ci_supports_color?
           color_terminal = ENV['TERM'].to_s.downcase.include?("color")
           $stdout.tty? || color_terminal
+        end
+        
+        def self.ci_supports_color?
+          # most CIs set this to `true`
+          return false unless ENV['CI'] == 'true'
+
+          # https://buildkite.com/docs/pipelines/environment-variables
+          return true if ENV['BUILDKITE'] == 'true'
+          # https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/variables#default-environment-variables
+          return true if ENV['GITHUB_ACTIONS'] == 'true'
+
+          false
         end
 
         if color?


### PR DESCRIPTION
I know of BuildKite and GitHub Actions at the very least that support terminal colors in their outputs.

This will save users having to do without color, or knowing they can turn it on themselves. Example:

https://github.com/charkost/prosopite/pull/55/files#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aR6-R7