### PR TITLE
Fix the hours and minutes computation in HTML reporter

### DIFF
--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -216,8 +216,8 @@ module Minitest
       def total_time_to_hms
         return ('%.2fs' % total_time) if total_time < 1
 
-        hours = (total_time / (60 * 60)).round
-        minutes = ((total_time / 60) % 60).round.to_s.rjust(2, '0')
+        hours = (total_time / (60 * 60)).floor
+        minutes = ((total_time / 60) % 60).floor.to_s.rjust(2, '0')
         seconds = (total_time % 60).round.to_s.rjust(2, '0')
 
         "#{hours}h#{minutes}m#{seconds}s"

--- a/test/unit/minitest/html_reporter_test.rb
+++ b/test/unit/minitest/html_reporter_test.rb
@@ -1,0 +1,14 @@
+require_relative "../../test_helper"
+
+module MinitestReportersTest
+  class HtmlReporterTest < Minitest::Test
+    def test_total_time_calculation
+      @reporter = Minitest::Reporters::HtmlReporter.new
+      @reporter.stub(:total_time, 2492.8) do
+        hms = @reporter.send(:total_time_to_hms)
+        assert_equal "0h41m33s", hms
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
In the HTML reporter hours and minutes were computed using "round" instead of "floor".

For instance:

**Before:**
total execution time 2492.8sec => 0h 41m 33sec
* hours: (2492.8 / (60 * 60)).round => 1h (incorrect)
* minutes: ((2492.8 / 60) % 60).round => 42m (incorrect)
* seconds: (2492.8 % 60).round => 33sec (correct)

**Now:**
total execution time 2492.8sec => 0h 41m 33sec
* hours: (2492.8 / (60 * 60)).floor => 0h
* minutes: ((2492.8 / 60) % 60).floor => 41m
* seconds: (2492.8 % 60).round => 33sec