### PR TITLE
Some minor documentation improvements

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,5 @@
 --readme          README.md
 --markup          markdown
---markup-provider maruku
 --default-return  ""
 --title           "Minitest-reporters Documentation"
 --hide-void-return

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ export MINITEST_REPORTER=JUnitReporter
 Detection of those systems is based on presence of certain ENV variables and are evaluated in the following order:
 
 ```
- MINITEST_REPORTER => use reporter indicated in env variable
- TM_PID => use RubyMateReporter
- RM_INFO => use RubyMineReporter
- TEAMCITY_VERSION => use RubyMineReporter
- VIM => disable all Reporters
+MINITEST_REPORTER => use reporter indicated in env variable
+TM_PID => use RubyMateReporter
+RM_INFO => use RubyMineReporter
+TEAMCITY_VERSION => use RubyMineReporter
+VIM => disable all Reporters
 ```
 
 The following reporters are provided:
@@ -77,15 +77,15 @@ Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => tru
 
 **Default Reporter**
 
-![Default Reporter](./assets/default-reporter.png?raw=true)
+![Default Reporter](https://raw.githubusercontent.com/minitest-reporters/minitest-reporters/master/assets/default-reporter.png)
 
 **Spec Reporter**
 
-![Spec Reporter](./assets/spec-reporter.png?raw=true)
+![Spec Reporter](https://raw.githubusercontent.com/minitest-reporters/minitest-reporters/master/assets/spec-reporter.png)
 
 **Progress Reporter**
 
-![Progress Reporter](./assets/progress-reporter.png?raw=true)
+![Progress Reporter](https://raw.githubusercontent.com/minitest-reporters/minitest-reporters/master/assets/progress-reporter.png)
 
 ## Caveats ##
 
@@ -104,11 +104,11 @@ happening if you see overly long or otherwise unexpected backtraces.)
 To avoid that, you must manually tell minitest-reporters which filter to use. In Rails,
 do this in `test_helper.rb`:
 ```ruby
-    Minitest::Reporters.use!(
-      Minitest::Reporters::DefaultReporter.new,
-      ENV,
-      Minitest.backtrace_filter
-    )
+Minitest::Reporters.use!(
+  Minitest::Reporters::DefaultReporter.new,
+  ENV,
+  Minitest.backtrace_filter
+)
 ```
 The third parameter to `.use!`, in this case `Minitest.backtrace_filter`, should be a
 filter object. In the above example, you're telling minitest-reporters to use the filter

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -12,7 +12,7 @@ module Minitest
 
       # The constructor takes an `options` hash
       # @param options [Hash]
-      # @option options print_failure_summary [Boolean] wether to print the errors at the bottom of the
+      # @option options print_failure_summary [Boolean] whether to print the errors at the bottom of the
       #   report or inline as they happen.
       #
       def initialize(options = {})

--- a/minitest-reporters.gemspec
+++ b/minitest-reporters.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'ruby-progressbar'
   s.add_dependency 'builder'
 
-  s.add_development_dependency 'maruku'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop'
 


### PR DESCRIPTION
Changes:
* Fixed image links - I couldn't find a way to make relative links work on rubydoc.info, so we're linking to the image URL instead.
* Removed development dependency on outdated markdown parser `maruku`. Yard seems to have no problems parsing markdown without it.
* Fixed some minor formatting/spelling issues.