### PR TITLE
Output failure screenshot when available

### DIFF
--- a/test/integration/reporters/junit_reporter_test.rb
+++ b/test/integration/reporters/junit_reporter_test.rb
@@ -8,5 +8,21 @@ module MinitestReportersTest
       output = `ruby #{test_filename} 2>&1`
       refute_match 'No such file or directory', output
     end
+
+    if Gem::Version.new(Minitest::VERSION) >= Gem::Version.new('5.19.0')
+      def test_outputs_screenshot_metadata
+        test = Minitest::Test.new('test_fail')
+        test.define_singleton_method(:test_fail) { assert false }
+        test.metadata = { failure_screenshot_path: 'screenshot.png' }
+
+        reporter = Minitest::Reporters::JUnitReporter.new('test/tmp')
+        reporter.start
+        reporter.record(test.run)
+        reporter.report
+
+        test_output = File.read('test/tmp/TEST-Minitest-Test.xml')
+        assert_includes test_output, '<system-out>[[ATTACHMENT|screenshot.png]]</system-out>'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Now that `minitest` supports adding custom metadata to tests and their results (https://github.com/minitest/minitest/issues/956) and `rails` automatically adds the failure screenshot path to the metadata (https://github.com/rails/rails/pull/48863) we can surface that metadata as an attachment in the JUnit output.

CI tools use this attachment to display the screenshot when parsing JUnit test reports (e.g. GitLab https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html#view-junit-screenshots-on-gitlab).

This is an example of what it looks like inside of the GitLab UI

<img width="773" alt="Screenshot 2023-08-05 at 15 05 16" src="https://github.com/minitest-reporters/minitest-reporters/assets/1218868/e51bda50-6552-4d61-ad64-3a67f8f1293c">
