### PR TITLE
Report durations and numbers with consistent significant figures

### DIFF
--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -61,6 +61,15 @@ module Minitest
         end
       end
 
+      def print_finished
+        puts('Finished in %.5fs' % total_time)
+        print('%d tests, %d assertions, ' % [count, assertions])
+        color = failures.zero? && errors.zero? ? :green : :red
+        print(send(color, '%d failures, %d errors, ') % [failures, errors])
+        print(yellow '%d skips' % skips)
+        puts
+      end
+
       protected
 
       def after_suite(test); end

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -62,7 +62,7 @@ module Minitest
       end
 
       def print_finished
-        puts('Finished in %.5fs' % total_time)
+        puts('Finished in %s' % format_duration(total_time))
         print('%d tests, %d assertions, ' % [count, assertions])
         color = failures.zero? && errors.zero? ? :green : :red
         print(send(color, '%d failures, %d errors, ') % [failures, errors])

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -70,6 +70,26 @@ module Minitest
         puts
       end
 
+      # @param sigfig [Integer] minimum number of digits to include (not including leading 0s if duration < 1s)
+      def format_duration(duration, sigfig: 3)
+        return('[negative duration]') if duration < 0 # duration should be positive, but nonmonotonic clock is possible
+
+        lg = duration == 0 ? 0 : Math.log10(duration).floor
+        if lg - sigfig + 1 < 0
+          seconds = "%.#{sigfig - lg - 1}f" % (duration % 60)
+        else
+          seconds = "%i" % (duration % 60)
+        end
+
+        if duration > 60 * 60
+          "%ih %im %ss" % [duration / 60 / 60, duration / 60 % 60, seconds]
+        elsif duration > 60
+          "%im %ss" % [duration / 60, seconds]
+        else
+          "%ss" % seconds
+        end
+      end
+
       protected
 
       def after_suite(test); end

--- a/lib/minitest/reporters/base_reporter.rb
+++ b/lib/minitest/reporters/base_reporter.rb
@@ -70,16 +70,10 @@ module Minitest
         puts
       end
 
-      # @param sigfig [Integer] minimum number of digits to include (not including leading 0s if duration < 1s)
       def format_duration(duration, sigfig: 3)
         return('[negative duration]') if duration < 0 # duration should be positive, but nonmonotonic clock is possible
 
-        lg = duration == 0 ? 0 : Math.log10(duration).floor
-        if lg - sigfig + 1 < 0
-          seconds = "%.#{sigfig - lg - 1}f" % (duration % 60)
-        else
-          seconds = "%i" % (duration % 60)
-        end
+        seconds = format_sigfig(duration, sigfig: sigfig, mod: 60)
 
         if duration > 60 * 60
           "%ih %im %ss" % [duration / 60 / 60, duration / 60 % 60, seconds]
@@ -87,6 +81,19 @@ module Minitest
           "%im %ss" % [duration / 60, seconds]
         else
           "%ss" % seconds
+        end
+      end
+
+      # @param sigfig [Integer] minimum number of digits to include (not including leading 0s if duration < 1s)
+      # @param mod the number of digits after the decimal point is computed from `n`,
+      #   but the formatted number returned will be `n` modulo this
+      def format_sigfig(n, sigfig: 3, mod: nil)
+        lg = n == 0 ? 0 : Math.log10(n.abs).floor
+        n = n % mod if mod
+        if lg - sigfig + 1 < 0
+          "%.#{sigfig - lg - 1}f" % n
+        else
+          "%i" % n
         end
       end
 

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -92,8 +92,8 @@ module Minitest
       end
 
       def on_report
-        status_line = "Finished tests in %s, %.4f tests/s, %.4f assertions/s." %
-          [format_duration(total_time), count / total_time, assertions / total_time]
+        status_line = "Finished tests in %s, %s tests/s, %s assertions/s." %
+          [format_duration(total_time), format_sigfig(count / total_time), format_sigfig(assertions / total_time)]
 
         puts
         puts

--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -57,7 +57,7 @@ module Minitest
       end
 
       def on_record(test)
-        print "#{"%.2f" % test.time} = " if options[:verbose]
+        print "#{format_duration(test.time)} = " if options[:verbose]
 
         # Print the pass/skip/fail mark
         print(if test.passed?
@@ -92,8 +92,8 @@ module Minitest
       end
 
       def on_report
-        status_line = "Finished tests in %.6fs, %.4f tests/s, %.4f assertions/s." %
-          [total_time, count / total_time, assertions / total_time]
+        status_line = "Finished tests in %s, %.4f tests/s, %.4f assertions/s." %
+          [format_duration(total_time), count / total_time, assertions / total_time]
 
         puts
         puts
@@ -114,7 +114,7 @@ module Minitest
           puts
 
           slow_tests.each do |test|
-            puts "%.6fs %s#%s" % [test.time, test.name, test_class(test)]
+            puts "%s %s#%s" % [format_duration(test.time), test.name, test_class(test)]
           end
         end
 
@@ -126,7 +126,7 @@ module Minitest
           puts
 
           slow_suites.each do |slow_suite|
-            puts "%.6fs %s" % [slow_suite[1], slow_suite[0]]
+            puts "%s %s" % [format_duration(slow_suite[1]), slow_suite[0]]
           end
         end
 

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -212,16 +212,6 @@ module Minitest
         end
         last_before_assertion.sub(/:in .*$/, '')
       end
-
-      def total_time_to_hms
-        return ('%.2fs' % total_time) if total_time < 1
-
-        hours = (total_time / (60 * 60)).round
-        minutes = ((total_time / 60) % 60).round.to_s.rjust(2, '0')
-        seconds = (total_time % 60).round.to_s.rjust(2, '0')
-
-        "#{hours}h#{minutes}m#{seconds}s"
-      end
     end
   end
 end

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -144,13 +144,23 @@ module Minitest
       #
       # @return [String]
       def report_body
-        order_sorted_body.each_with_object([]) do |result, obj|
+        body = order_sorted_body
+        lengths = {}
+        numkeys = [:avg, :min, :max, :last]
+        body.each do |result|
+          numkeys.each do |key|
+            formatted = format_sigfig(result[key])
+            result[:"format_#{key}"] = formatted
+            lengths[key] = formatted.size if !lengths.key?(key) || lengths[key] < formatted.size
+          end
+        end
+        body.each_with_object([]) do |result, obj|
           rating = rate(result[:last], result[:min], result[:max])
 
-          obj << "#{avg_label} #{result[:avg].to_s.ljust(12)} " \
-                 "#{min_label} #{result[:min].to_s.ljust(12)} " \
-                 "#{max_label} #{result[:max].to_s.ljust(12)} " \
-                 "#{run_label(rating)} #{result[:last].to_s.ljust(12)} " \
+          obj << "#{avg_label} #{result[:format_avg].ljust(lengths[:avg])}   " \
+                 "#{min_label} #{result[:format_min].ljust(lengths[:min])}   " \
+                 "#{max_label} #{result[:format_max].ljust(lengths[:max])}   " \
+                 "#{run_label(rating)} #{result[:format_last].ljust(lengths[:last])}   " \
                  "#{des_label} #{result[:desc]}\n"
         end.join
       end
@@ -176,10 +186,10 @@ module Minitest
           size = Array(timings).size
           sum  = Array(timings).inject { |total, x| total + x }
           obj << {
-            avg:  (sum / size).round(9),
-            min:  Array(timings).min.round(9),
-            max:  Array(timings).max.round(9),
-            last: Array(timings).last.round(9),
+            avg:  sum / size,
+            min:  Array(timings).min,
+            max:  Array(timings).max,
+            last: Array(timings).last,
             desc: description,
           }
         end.sort_by { |k| k[sort_column] }

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -72,12 +72,7 @@ module Minitest
         @progress.finish
 
         puts
-        puts('Finished in %.5fs' % total_time)
-        print('%d tests, %d assertions, ' % [count, assertions])
-        color = failures.zero? && errors.zero? ? :green : :red
-        print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
-        print(yellow { '%d skips' } % skips)
-        puts
+        print_finished
       end
 
       private

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -82,7 +82,7 @@ module Minitest
       end
 
       def print_test_with_time(test)
-        print(" %s#%s (%.2fs)" % [test_class(test), test.name, total_time])
+        print(" %s#%s (%s)" % [test_class(test), test.name, format_duration(total_time)])
       end
 
       def color

--- a/lib/minitest/reporters/ruby_mate_reporter.rb
+++ b/lib/minitest/reporters/ruby_mate_reporter.rb
@@ -37,7 +37,7 @@ module Minitest
       def report
         super
         puts
-        puts('Finished in %.5fs' % total_time)
+        puts('Finished in %s' % format_duration(total_time))
         print('%d tests, %d assertions, ' % [count, assertions])
         print('%d failures, %d errors, ' % [failures, errors])
         print('%d skips' % skips)
@@ -47,7 +47,7 @@ module Minitest
       private
 
       def print_test_with_time(test)
-        print(" #{test.class}##{test.name} (%.2fs)" % test.time)
+        print(" #{test.class}##{test.name} (%s)" % format_duration(test.time))
       end
     end
   end

--- a/lib/minitest/reporters/rubymine_reporter.rb
+++ b/lib/minitest/reporters/rubymine_reporter.rb
@@ -52,12 +52,7 @@ else
 
         def report
           super
-
-          puts('Finished in %.5fs' % total_time)
-          print('%d tests, %d assertions, ' % [count, assertions])
-          print(red '%d failures, %d errors, ' % [failures, errors])
-          print(yellow '%d skips' % skips)
-          puts
+          print_finished
         end
 
         def record(test)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -39,12 +39,7 @@ module Minitest
           end
         end
 
-        puts('Finished in %.5fs' % total_time)
-        print('%d tests, %d assertions, ' % [count, assertions])
-        color = failures.zero? && errors.zero? ? :green : :red
-        print(send(color) { '%d failures, %d errors, ' } % [failures, errors])
-        print(yellow { '%d skips' } % skips)
-        puts
+        print_finished
       end
 
       def record(test)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -79,7 +79,7 @@ module Minitest
         test_name = test.name.gsub(/^test_: /, 'test:')
         print pad_test(test_name)
         print_colored_status(test)
-        print(" (%.2fs)" % test.time) unless test.time.nil?
+        print(" (%s)" % format_duration(test.time)) unless test.time.nil?
         puts
       end
     end

--- a/lib/minitest/templates/index.html.erb
+++ b/lib/minitest/templates/index.html.erb
@@ -15,7 +15,7 @@
         <h1>
             <%= title %></h1>
         <p>
-            Finished in <%= total_time_to_hms %>, <%= '%.2f tests/s' % (count / total_time) %>, <%= '%.2f assertions/s' % (assertions / total_time) %>
+            Finished in <%= format_duration(total_time) %>, <%= '%.2f tests/s' % (count / total_time) %>, <%= '%.2f assertions/s' % (assertions / total_time) %>
         </p>
         <p>
             <strong>
@@ -51,7 +51,7 @@
                     <span class="<%= 'text-danger' if suite[:fail_count] > 0 %>"> <%= '%d' % suite[:fail_count] %> failures</span>,
                     <span class="<%= 'text-danger' if suite[:error_count] > 0 %>"> <%= '%d' % suite[:error_count] %> errors</span>,
                     <span class="<%= 'text-warning' if suite[:skip_count] > 0 %>"> <%= '%d' % suite[:skip_count] %> skips</span>,
-                    <span> finished in <%= '%.4fs' % suite[:time] %></span>
+                    <span> finished in <%= format_duration(suite[:time]) %></span>
                 </span>
             </div>
             <div class="panel-body">
@@ -68,7 +68,7 @@
                                 <% end %>
                                 <%= friendly_name(test) %>
                                 <span class="pull-right">
-                                    Assertions <%= test.assertions %>, time <%= ('%.6fs' % test.time) %>
+                                    Assertions <%= test.assertions %>, time <%= format_duration(test.time) %>
                                 </span>
                             </h5>
                             <% if !test.passed? %>

--- a/lib/minitest/templates/index.html.erb
+++ b/lib/minitest/templates/index.html.erb
@@ -15,7 +15,7 @@
         <h1>
             <%= title %></h1>
         <p>
-            Finished in <%= format_duration(total_time) %>, <%= '%.2f tests/s' % (count / total_time) %>, <%= '%.2f assertions/s' % (assertions / total_time) %>
+            Finished in <%= format_duration(total_time) %>, <%= format_sigfig(count / total_time) %> tests/s, <%= format_sigfig(assertions / total_time) %> assertions/s
         </p>
         <p>
             <strong>


### PR DESCRIPTION
Currently reporters use a fixed number of digits after a decimal to report test duration and other numbers, though the number of digits varies from 0 (whole numbers) all the way to 6. Since tests have a huge range of execution time, this can result in not-very-useful numbers in both directions: giving microsecond precision on a test that takes two minutes is unnecessary information that's harder to parse; on the other hand a test that takes some microseconds is, in some places, truncated to 0.00.

This PR changes reporting to include 3 [significant figures](https://en.wikipedia.org/wiki/Significant_figures) on all numbers (barring any that I missed). 3 seems like at least as much precision as is significant in these reports - the amount of time tests take always varies more than this (in my experience).

I also split durations into hour/minute/second rather than always just reporting seconds.

Before:

```
test_0001_fast_test   PASS (0.00s)
test_0002_slow_test   PASS (105.00s)

Finished in 105.09427s
```

After:

```
test_0001_fast_test   PASS (0.00114s)
test_0002_slow_test   PASS (1m 45s)

Finished in 1m 45s
```

MeanTimeReporter before:

```
Finished tests in 103.051912s, 0.0194 tests/s, 1.0092 assertions/s.
2 tests, 102 assertions, 0 failures, 0 errors, 0 skips

Minitest Reporters: Mean Time Report (Samples: 5, Order: :avg :desc)
Avg: 102.81607025 Min: 101.051376   Max: 105.07253    Last: 103.051096   Description: slow
Avg: 0.001024625  Min: 0.000411     Max: 0.001939     Last: 0.000629     Description: fast
```

After:

```
Finished tests in 1m 44s, 0.0192 tests/s, 1.01 assertions/s.
2 tests, 102 assertions, 0 failures, 0 errors, 0 skips

Minitest Reporters: Mean Time Report (Samples: 5, Order: :avg :desc)
Avg: 102       Min: 101        Max: 105       Last: 104        Description: slow
Avg: 0.00115   Min: 0.000411   Max: 0.00194   Last: 0.000437   Description: fast
```