### PR TITLE
Switch progress bar default format to proper fraction

### DIFF
--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -24,7 +24,7 @@ module Minitest
           starting_at:    count,
           progress_mark:  green(PROGRESS_MARK),
           remainder_mark: ' ',
-          format:         options.fetch(:format, '  %C/%c: [%B] %p%% %a, %e'),
+          format:         options.fetch(:format, '  %c/%C: [%B] %p%% %a, %e'),
           autostart:      false
         )
       end


### PR DESCRIPTION
This patch switches the progress bar's default format to display the completed test count in the numerator and the total test count in the denominator, as in "52/2182" rather than "2182/52".

Displaying progress as a proper fraction is more intuitive given the fraction-like notation we use here and corresponds nicely to the "2%" completion status that we also display in the default format.

Historically, the ProgressReporter used to use a proper fraction format, but that was changed in 2013 in commit 4a15b7b without explanation -- it may not have even been intentional. A subsequent refactoring from 2014 in commit 25ac5cd5 replaced PowerBar with ruby-progressbar, and it faithfully preserved this (likely accidental) convention.

So... think of this PR as a fix to a regression from 10 years ago.

The ProgressReporter's format is configurable, so users who prefer seeing the old "total/completed" format should instantiate their reporter as follows:

```ruby
Minitest::Reporters::ProgressReporter.new(format: '  %C/%c: [%B] %p%% %a, %e')
```

