### PR TITLE
Adds explicit option to `suppress_inline_failure_output` to `SpecReporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Updated `JUnitReporter` to output a failure screenshot path when included in the minitest result [#346](https://github.com/minitest-reporters/minitest-reporters/pull/346) contributed by [matteeyah](https://github.com/matteeyah)
 * Fixed backwards fraction in `ProgressReporter` default format [#348](https://github.com/minitest-reporters/minitest-reporters/pull/348) contributed by [notEthan](https://github.com/notEthan)
 * Added option `suppress_inline_failure_output` to `SpecReporter` to provide an explicit switch, separate from `print_failure_summary`, for suppressing inline failure messages. Until this change, the `print_failure_summary` would do both: print a failure/error summary after all tests run and suppress the inline failure messages. With this change `print_failure_summary` will just add a summary at the end of a test run, and it will no longer suppress the inline failure messages.
-  as they happen [#306](https://github.com/minitest-reporters/minitest-reporters/pull/306) contributed by [picandocodigo](https://github.com/picandocodigo)
 
 ### [1.6.1](https://github.com/kern/minitest-reporters/compare/v1.6.0...v1.6.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added Ruby 3.2 to the CI matrix [#335](https://github.com/minitest-reporters/minitest-reporters/pull/335) contributed by [petergoldstein](https://github.com/petergoldstein)
 * Updated `JUnitReporter` to output a failure screenshot path when included in the minitest result [#346](https://github.com/minitest-reporters/minitest-reporters/pull/346) contributed by [matteeyah](https://github.com/matteeyah)
 * Fixed backwards fraction in `ProgressReporter` default format [#348](https://github.com/minitest-reporters/minitest-reporters/pull/348) contributed by [notEthan](https://github.com/notEthan)
+* Added option `suppress_inline_failure_output` to `SpecReporter` to provide an explicit switch, separate from `print_failure_summary`, for suppressing inline failure messages. Until this change, the `print_failure_summary` would do both: print a failure/error summary after all tests run and suppress the inline failure messages. With this change `print_failure_summary` will just add a summary at the end of a test run, and it will no longer suppress the inline failure messages.
+  as they happen [#306](https://github.com/minitest-reporters/minitest-reporters/pull/306) contributed by [picandocodigo](https://github.com/picandocodigo)
 
 ### [1.6.1](https://github.com/kern/minitest-reporters/compare/v1.6.0...v1.6.1)
 

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -18,6 +18,7 @@ module Minitest
       def initialize(options = {})
         super
         @print_failure_summary = options[:print_failure_summary]
+        @suppress_inline_failure_output = options[:suppress_inline_failure_output]
       end
 
       def start
@@ -50,7 +51,7 @@ module Minitest
       def record(test)
         super
         record_print_status(test)
-        record_print_failures_if_any(test) unless @print_failure_summary
+        record_print_failures_if_any(test) if @suppress_inline_failure_output
       end
 
       protected

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -13,7 +13,9 @@ module Minitest
       # The constructor takes an `options` hash
       # @param options [Hash]
       # @option options print_failure_summary [Boolean] whether to print the errors at the bottom of the
-      #   report or inline as they happen.
+      #   report.
+      # @option options suppress_inline_failure_output [Boolean] whether to suppress the printing of errors
+      #   inline with the test results as they occur.
       #
       def initialize(options = {})
         super


### PR DESCRIPTION
Provides an explicit switch, separate from `print_failure_summary`, for suppressing inline failure messages.

  - Until this change, the `print_failure_summary` would do both: print a failure/error summary after all tests run and suppress the inline failure messages.
  - With this change `print_failure_summary` will just add a summary at the end of a test run, and it will no longer suppress the inline failure messages.

  The summary added in #306 is indeed helpful to prevent need for scanning a large number of
  tests' output.

  The inline output is helpful for immediately getting to work on
  addressing some test failure without waiting for all tests to finish.

  Our project opted in to `print_failure_summary` (which is nice) but
  I found the inconvenience of needing to wait for the tests to
  conclude before taking action to be a great hindrance.