### PR TITLE
feat: Add GithubReporter to Minitest::Reporters

### DIFF
--- a/lib/minitest/reporters.rb
+++ b/lib/minitest/reporters.rb
@@ -17,6 +17,7 @@ module Minitest
     autoload :JUnitReporter, "minitest/reporters/junit_reporter"
     autoload :HtmlReporter, "minitest/reporters/html_reporter"
     autoload :MeanTimeReporter, "minitest/reporters/mean_time_reporter"
+    autoload :GithubReporter, "minitest/reporters/github_reporter"
 
     class << self
       attr_accessor :reporters

--- a/lib/minitest/reporters/github_reporter.rb
+++ b/lib/minitest/reporters/github_reporter.rb
@@ -1,0 +1,45 @@
+module Minitest
+  module Reporters
+    class GithubReporter < BaseReporter
+      def record(test)
+        super
+
+        type = determine_type(test)
+        output = create_output(test)
+        message = test.failure
+
+        puts "#{type} #{output.join(',')}::#{message}"
+      end
+
+      private
+
+      def determine_type(test)
+        if test.skipped?
+          "::notice"
+        elsif test.error? || test.failure
+          "::error"
+        end
+      end
+
+      def create_output(test)
+        {
+          file: relative_path(test.source_location[0]),
+          line: test.source_location[1],
+          title: test.name,
+        }.map { |k, v| "#{k}=#{escape_properties(v)}" }
+      end
+
+      def relative_path(path)
+        Pathname.new(path).relative_path_from(Pathname.new(Dir.getwd))
+      end
+
+      def escape_properties(string)
+        string.to_s.gsub("%", '%25')
+              .gsub("\r", '%0D')
+              .gsub("\n", '%0A')
+              .gsub(":", '%3A')
+              .gsub(",", '%2C')
+      end
+    end
+  end
+end

--- a/test/fixtures/github_test.rb
+++ b/test/fixtures/github_test.rb
@@ -1,0 +1,7 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'minitest/reporters'
+
+Minitest::Reporters.use! Minitest::Reporters::GithubReporter.new
+
+require_relative 'sample_test'

--- a/test/integration/reporters/github_reporter_test.rb
+++ b/test/integration/reporters/github_reporter_test.rb
@@ -1,0 +1,20 @@
+require_relative "../../test_helper"
+
+module MinitestReportersTest
+  class GithubReporterTest < TestCase
+    def test_failure_displayed
+      fixtures_directory = File.expand_path('../../fixtures', __dir__)
+      test_filename = File.join(fixtures_directory, 'github_test.rb')
+      output = `#{ruby_executable} #{test_filename} 2>&1`
+      assert_match "::error file=test/fixtures/sample_test.rb,line=11,title=test_error::Unexpected exception", output
+      assert_match "::error file=test/fixtures/sample_test.rb,line=5,title=test_failure::Expected false to be truthy.", output
+      assert_match "::notice file=test/fixtures/sample_test.rb,line=8,title=test_skip::Skipping rope", output
+    end
+
+    private
+
+    def ruby_executable
+      defined?(JRUBY_VERSION) ? 'jruby' : 'ruby'
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new reporter, GithubReporter, to the Minitest::Reporters module. The GithubReporter is responsible for recording test results and outputting them in a format compatible with GitHub Actions. It determines the type of the test (notice, error, or skipped) and creates an output string containing the file, line, and title of the test. The output is then printed to the console.

The GithubReporter is implemented as a subclass of BaseReporter and includes methods for determining the type of the test, creating the output string, and escaping special characters in the output. It also includes a private method for converting absolute file paths to relative paths.

This commit also includes the necessary changes to the lib/minitest/reporters.rb file to autoload the GithubReporter class.

The addition of the GithubReporter provides a new way to report test results in a format that is compatible with [GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message), making it easier to integrate Minitest with CI/CD pipelines.

