### PR TITLE
Fix logic of new suppress_inline_failure_output option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### [dev](https://github.com/minitest-reporters/minitest-reporters/compare/v1.7.0...master)
+* Fixed logic of new `suppress_inline_failure_output`. This option was doing the opposite of what it intended to do.
+  [#354](https://github.com/minitest-reporters/minitest-reporters/pull/354)
 
 ### [1.7.0](https://github.com/minitest-reporters/minitest-reporters/compare/v1.6.1...v1.7.0)
 

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -53,7 +53,7 @@ module Minitest
       def record(test)
         super
         record_print_status(test)
-        record_print_failures_if_any(test) if @suppress_inline_failure_output
+        record_print_failures_if_any(test) unless @suppress_inline_failure_output
       end
 
       protected


### PR DESCRIPTION
`suppress_inline_failure_output` was actually doing the opposite of what it claimed to do. This commit reverses that.