### PR TITLE
Improve documentation for most reporters

### DIFF
--- a/lib/minitest/reporters/default_reporter.rb
+++ b/lib/minitest/reporters/default_reporter.rb
@@ -11,6 +11,20 @@ module Minitest
       include ANSI::Code
       include RelativePosition
 
+      # @param options [Hash]
+      # @option options :detailed_skip [Boolean] (true) If this is set to `false`, `DefaultReporter` will omit details
+      #   about the skipped tests such as the name and location of the skipped test as well as the skip message.
+      # @option options :slow_count [Integer] (0) If this is set to a number greater than 0, `DefaultReporter` will
+      #   print information about the slowest tests. The number of tests printed will be equal to the value of
+      #   `slow_count`.
+      # @option options :slow_suite_count [Integer] (0) If this is set to a number greater than 0, `DefaultReporter`
+      #   will print information about the slowest test classes. The number of test classes printed will be equal to
+      #   the value of `slow_suite_count`.
+      # @option options :fast_fail [Boolean] (false) If this is set to `true`, `DefaultReporter` will print information
+      #  about test failures as soon as they occur instead of waiting until the end of the test run.
+      # @option options :location [Boolean] (false) If this is set to `true`, `DefaultReporter` will print the location
+      #   where the test definition begins after the failure message for failing tests.
+      #
       def initialize(options = {})
         super
         @detailed_skip = options.fetch(:detailed_skip, true)

--- a/lib/minitest/reporters/html_reporter.rb
+++ b/lib/minitest/reporters/html_reporter.rb
@@ -51,12 +51,16 @@ module Minitest
         "it #{groups[0][1]}"
       end
 
-      # The constructor takes a hash, and uses the following keys:
-      # :title - the title that will be used in the report, defaults to 'Test Results'
-      # :reports_dir - the directory the reports should be written to, defaults to 'test/html_reports'
-      # :erb_template - the path to a custom ERB template, defaults to the supplied ERB template
-      # :mode - Useful for debugging, :terse suppresses errors and is the default, :verbose lets errors bubble up
-      # :output_filename - the report's filename, defaults to 'index.html'
+      # @param args [Hash]
+      # @option args :title [Boolean] ('Test Results') the title that will be used in the report.
+      # @option args :reports_dir [Boolean] ('test/html_reports') the directory the reports should be written to. You
+      #   can also set this using the environment variable `MINITEST_HTML_REPORTS_DIR`.
+      # @option args :erb_template [Boolean] the path to a custom ERB template. If this is omitted, the template
+      #   supplied by minitest-reporters will be used.
+      # @option args :mode [Boolean] (:terse) Useful for debugging, `:terse` suppresses errors and `:verbose` lets
+      #   errors bubble up.
+      # @option args :output_filename [Boolean] ('index.html') the report's filename. You can also set this using
+      #   the environment variable `MINITEST_HTML_REPORTS_FILENAME`.
       def initialize(args = {})
         super({})
 

--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -18,6 +18,19 @@ module Minitest
 
       attr_reader :reports_path
 
+      # @param reports_dir [String] The directory where the XML reports will be written. You can also specify this path
+      #   by setting the `MINITEST_REPORTERS_REPORTS_DIR` environment variable.
+      # @param empty [Boolean] If this is set to true, `JUnitReporter` will empty the reports directory before
+      #   writing the XML reports.
+      # @param options [Hash]
+      # @option options :single_file [Boolean] (false) If this is set to true, `JUnitReporter` will write all test
+      #   results to a single XML file. Otherwise, it will write one XML file per test class.
+      # @option options :base_path [String] (Dir.pwd) If this is set, `JUnitReporter` will use this path as the base
+      #   path for the test file paths in the XML reports. Otherwise, it will use the current working directory. The
+      #   `filepath` attribute in the `testsuite` element in the report XML will be relative to this path.
+      # @option options :include_timestamp [Boolean] (false) If this is set to true, `JUnitReporter` will include
+      #   a `timestamp` attribute recording the time the report was generated in the `testsuite` element in the report
+      #   XML.
       def initialize(reports_dir = DEFAULT_REPORTS_DIR, empty = true, options = {})
         super({})
         @reports_path = File.absolute_path(ENV.fetch("MINITEST_REPORTERS_REPORTS_DIR", reports_dir))

--- a/lib/minitest/reporters/mean_time_reporter.rb
+++ b/lib/minitest/reporters/mean_time_reporter.rb
@@ -35,20 +35,18 @@ module Minitest
       end
 
       # @param options [Hash]
-      # @option previous_runs_filename [String] Contains the times for each test
-      #   by description. Defaults to '/tmp/minitest_reporters_previous_run'.
-      # @option report_filename [String] Contains the parsed results for the
-      #   last test run. Defaults to '/tmp/minitest_reporters_report'.
-      # @option show_count [Fixnum] The number of tests to show in the report
-      #   summary at the end of the test run. Default is 15.
-      # @option show_progress [Boolean] If true it prints pass/skip/fail marks.
-      #   Default is true.
-      # @option show_all_runs [Boolean] If true it shows all recorded suit results.
-      #   Default is true.
-      # @option sort_column [Symbol] One of :avg (default), :min, :max, :last.
+      # @option options :previous_runs_filename [String] ('/tmp/minitest_reporters_previous_run') Contains the times for
+      #   each test by description.
+      # @option options :report_filename [String] ('/tmp/minitest_reporters_report') Contains the parsed results for the
+      #   last test run.
+      # @option options :show_count [Integer] (15) The number of tests to show in the report
+      #   summary at the end of the test run.
+      # @option options :show_progress [Boolean] (true) If true it prints pass/skip/fail marks.
+      # @option options :show_all_runs [Boolean] (true) If true it shows all recorded suit results.
+      # @option options :sort_column [Symbol] (:avg) One of `:avg`, `:min`, `:max`, `:last`.
       #   Determines the column by which the report summary is sorted.
-      # @option order [Symbol] One of :desc (default), or :asc. By default the
-      #   report summary is listed slowest to fastest (:desc). :asc will order
+      # @option options :order [Symbol] (:desc) One of `:desc` or `:asc`. By default the
+      #   report summary is listed slowest to fastest (`:desc`). `:asc` will order
       #   the report summary as fastest to slowest.
       # @return [Minitest::Reporters::MeanTimeReporter]
       def initialize(options = {})
@@ -190,7 +188,7 @@ module Minitest
         defaults.merge!(@options)
       end
 
-      # @return [Fixnum] The number of tests to output to output to the screen
+      # @return [Integer] The number of tests to output to output to the screen
       #   after each run.
       def show_count
         options[:show_count]
@@ -234,7 +232,7 @@ module Minitest
       #
       #    rake reset_statistics
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def samples
         return 1 unless previous_run.first[1].is_a?(Array)
 

--- a/lib/minitest/reporters/progress_reporter.rb
+++ b/lib/minitest/reporters/progress_reporter.rb
@@ -15,6 +15,9 @@ module Minitest
 
       PROGRESS_MARK = '='.freeze
 
+      # @param options [Hash]
+      # @option options :detailed_skip [Boolean] (true) If this is set to false, `ProgressReporter` will omit detailed
+      #  information about skipped tests, but will still show the total number of skipped tests in the summary line.
       def initialize(options = {})
         super
         @detailed_skip = options.fetch(:detailed_skip, true)

--- a/lib/minitest/reporters/spec_reporter.rb
+++ b/lib/minitest/reporters/spec_reporter.rb
@@ -10,13 +10,11 @@ module Minitest
       include ANSI::Code
       include RelativePosition
 
-      # The constructor takes an `options` hash
       # @param options [Hash]
-      # @option options print_failure_summary [Boolean] whether to print the errors at the bottom of the
-      #   report.
-      # @option options suppress_inline_failure_output [Boolean] whether to suppress the printing of errors
-      #   inline with the test results as they occur.
-      #
+      # @option options :print_failure_summary [Boolean] (false) If this is set to true, `SpecReporter` will print a
+      #   summary of test failure details at the end of the test run instead of when the failure occurs.
+      # @option options :suppress_inline_failure_output [Boolean] (false) If this is set to true, `SpecReporter` will
+      #   suppress the printing of errors inline with the test results as they occur.
       def initialize(options = {})
         super
         @print_failure_summary = options[:print_failure_summary]


### PR DESCRIPTION
This PR adds or updates documentation for all of the various options each reporter supports. Previously, quite a few options were undocumented.

We're also now using Yard's `@option` tag more consistently (https://www.rubydoc.info/gems/yard/file/docs/Tags.md#option). This should improve how the docs look on rubydoc.info.