### PR TITLE
Use each test's individual file path for the JUnitReporter

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -96,10 +96,11 @@ module Minitest
 
         xml.testsuite(testsuite_attributes) do
           tests.each do |test|
+            test_file_path = get_relative_path(test)
             lineno = get_source_location(test).last
             xml.testcase(
               :name => test.name, :lineno => lineno, :classname => suite,
-              :assertions => test.assertions, :time => test.time, :file => file_path
+              :assertions => test.assertions, :time => test.time, :file => test_file_path
             ) do
               xml << xml_message_for(test) unless test.passed?
               xml << xml_attachment_for(test) if test.respond_to?('metadata') && test.metadata[:failure_screenshot_path]


### PR DESCRIPTION
If a test class is defined in two different files, the first file path would be used for the testcases in the second file as well. This change uses the actual file that the test case is contained in.